### PR TITLE
Improve failure tolerance (skipping failures)

### DIFF
--- a/metrics-calculator/src/main/java/domain/code/CodeSample.java
+++ b/metrics-calculator/src/main/java/domain/code/CodeSample.java
@@ -78,7 +78,7 @@ public abstract class CodeSample {
                 .filter(metric -> metric.hasTheSameName(metricName))
                 .findAny()
                 .map(metric -> metric.getValue().toString())
-                .orElseThrow();
+                .orElse("N/A");
     }
 
 }

--- a/metrics-calculator/src/main/java/gitapi/callablecommitsapi/fileversionsapi/FileVersionsApi.java
+++ b/metrics-calculator/src/main/java/gitapi/callablecommitsapi/fileversionsapi/FileVersionsApi.java
@@ -3,8 +3,12 @@ package gitapi.callablecommitsapi.fileversionsapi;
 import domain.git.Repository;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
+import org.apache.commons.io.FileUtils;
 import utils.ProcessExecutor;
 
+import java.io.File;
+import java.net.URL;
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -40,10 +44,15 @@ public class FileVersionsApi {
         fileVersions.forEach(fileVersion -> downloadFileVersionToDirectory(directoryAbsolutePath, fileVersion));
     }
 
+    @SneakyThrows
     private static void downloadFileVersionToDirectory(String directoryAbsolutePath,
                                                        FileVersion fileVersion) {
-        List<String> command = List.of("wget", "-O", fileVersion.getFileName(), fileVersion.getFileURI());
-        ProcessExecutor.executeCommandAndReturnProcessLogs(directoryAbsolutePath, command);
+        File path = new File(directoryAbsolutePath);
+        if(!path.getParentFile().exists()) {
+            path.mkdirs();
+        }
+
+        FileUtils.copyURLToFile(new URL(fileVersion.getFileURI()), new File(directoryAbsolutePath + "/" + fileVersion.getFileName()));
     }
 
 }

--- a/metrics-calculator/src/main/java/input/codesampleprovider/CodeSamplesProvider.java
+++ b/metrics-calculator/src/main/java/input/codesampleprovider/CodeSamplesProvider.java
@@ -35,7 +35,15 @@ public class CodeSamplesProvider {
     private static List<CodeSample> getAllCodeSamples(List<CSVInputRow> rows,
                                                       List<Repository> repositories) {
         return rows.stream()
-                .map(row -> getCodeSample(row, repositories))
+                .map(row -> {
+                    try {
+                        return getCodeSample(row, repositories);
+                    } catch (Exception ex) {
+                        System.err.println("Failed to fetch repository for " + row.getSampleId() + ". Exception: " + ex);
+                        return null;
+                    }
+                })
+                .filter(x -> x != null)
                 .toList();
     }
 

--- a/metrics-calculator/src/main/java/input/repositoryprovider/RepositoriesProvider.java
+++ b/metrics-calculator/src/main/java/input/repositoryprovider/RepositoriesProvider.java
@@ -21,11 +21,18 @@ public class RepositoriesProvider {
 
         for (CSVInputRow row : distinctRows) {
             Repository repository = RepositoryMapper.from(row);
-            repositories.add(repository);
+            if(repository.isAvailable()) {
+                repositories.add(repository);
+            } else {
+                System.out.println("Repository unavailable. Dropping " + repository.getAbsolutePath());
+            }
             doneElements++;
             System.out.println(repository);
             System.out.println("Done repositories : " + doneElements + "/" + allElements);
         }
+
+        System.out.println("Finally got " + repositories.size() + " repositories to analyze");
+
         return repositories;
     }
 

--- a/metrics-calculator/src/main/java/output/writer/CallableRowsWriter.java
+++ b/metrics-calculator/src/main/java/output/writer/CallableRowsWriter.java
@@ -21,7 +21,7 @@ public class CallableRowsWriter {
             printer = getPrinter(out);
             List<CodeSample> callables = getCallables(codeSamples);
             callables.forEach(CallableRowsWriter::printCallable);
-        } catch (IOException ex) {
+        } catch (Exception ex) {
             ex.printStackTrace();
         }
     }

--- a/metrics-calculator/src/main/java/service/MetricsCalculatorService.java
+++ b/metrics-calculator/src/main/java/service/MetricsCalculatorService.java
@@ -34,11 +34,15 @@ public class MetricsCalculatorService {
 
         System.out.println("Number of code samples: " + codeSamples.size());
         for (CodeSample codeSample : codeSamples) {
-            System.out.println("Sample id: " + codeSample.getId());
-            codeSample.calculateProductMetrics();
-            codeSample.calculateProcessMetrics();
             doneElements++;
-            System.out.println("Done code sample : " + doneElements + "/" + allElements);
+            try {
+                System.out.println("Sample id: " + codeSample.getId());
+                codeSample.calculateProductMetrics();
+                codeSample.calculateProcessMetrics();
+                System.out.println("Done code sample : " + doneElements + "/" + allElements);
+            } catch(Exception ex) {
+                System.err.println("Failed code sample : " + doneElements + "/" + allElements + ": " + ex);
+            }
         }
 
         List<CodeSample> processedCodeSamples = codeSamples.stream()

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <java.version>17</java.version>
         <javaparser.symbol.solver.core.version>3.16.1</javaparser.symbol.solver.core.version>
         <commons.csv.version>1.7</commons.csv.version>
+        <commons.io.version>2.11.0</commons.io.version>
         <guava.version>30.1-jre</guava.version>
         <lombok.version>1.18.22</lombok.version>
         <vavr.version>0.9.0</vavr.version>
@@ -54,6 +55,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
             <version>${commons.csv.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons.io.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
- use default "N/A" value instead of throwing if single metric calculation has failed
- support remotes that are not configured in the data set (only in RepositoryApi, downloads still go to GitHub)
- skip repositories that are unavailable
- use Apache Commons IO instead of external wget process to download files
- skip code samples that fail preparation step (e.g. cannot be downloaded)
- skip samples that critically failed metrics calculation